### PR TITLE
Fix compilation errors with gcc 13.1

### DIFF
--- a/stable_diffusion_ov/include/cpp_stable_diffusion_ov/model_collateral_cache.h
+++ b/stable_diffusion_ov/include/cpp_stable_diffusion_ov/model_collateral_cache.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <optional>
 #include <memory>
+#include <string>
 #include "cpp_stable_diffusion_ov/visibility.h"
 
 namespace cpp_stable_diffusion_ov

--- a/stable_diffusion_ov/include/cpp_stable_diffusion_ov/special_tokens_mixin.h
+++ b/stable_diffusion_ov/include/cpp_stable_diffusion_ov/special_tokens_mixin.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <stdexcept>
 #include <iostream>
+#include <cstdint>
 #include "cpp_stable_diffusion_ov/visibility.h"
 
 namespace cpp_stable_diffusion_ov

--- a/stable_diffusion_ov/tokenizers/clip-vocab.h
+++ b/stable_diffusion_ov/tokenizers/clip-vocab.h
@@ -1,6 +1,9 @@
 // Copyright(C) 2023 Intel Corporation
 // SPDX - License - Identifier: Apache - 2.0
 #pragma once
+
+#include <cstdint>
+
 namespace cpp_stable_diffusion_ov
 {
 static const size_t TOTAL_CLIP_VOCAB_PAIRS = 49408;


### PR DESCRIPTION
Resolves this issue: https://github.com/intel/stablediffusion-pipelines-cpp/issues/2

Tested on Ubuntu 22.04 with default compiler (GCC 11), and with GCC 13.1 of course. Also tested on Windows with VS 2019.