### PR TITLE
support batch2 unet models, introduce the notion of a 'unet subdir'

### DIFF
--- a/doc/build_doc/windows/README.md
+++ b/doc/build_doc/windows/README.md
@@ -47,12 +47,6 @@ Here are some of the dependencies that you need to grab, and a quick description
     git lfs install
     git clone https://huggingface.co/Intel/sd-1.5-square-quantized
 
-    :: copy the text_encoder, vae_decoder, vae_encoder .xml/.bin files into INT8 sub-directory
-    cd sd-1.5-square-quantized
-    copy /y *.xml INT8
-    copy /y *.bin INT8
-    cd ..
-
     :: Time to run the txt-to-image example. 
 
     :: Start by going to the folder containing 'txt_to_img.exe' that you previously built.
@@ -66,6 +60,7 @@ Here are some of the dependencies that you need to grab, and a quick description
     --guidance_scale=8.0
     --num_inference_steps=20
     --model_dir="C:\Path\To\Some\Model_Dir"
+    --unet_subdir="INT8" or "FP16"
     --text_encoder_device=CPU
     --unet_positive_device=CPU
     --unet_negative_device=CPU
@@ -74,16 +69,20 @@ Here are some of the dependencies that you need to grab, and a quick description
     --input_image=C:\SomePath\img.png
     --strength=0.75
 
-    :: For --model_dir parameter, we will use the 'sd-1.5-square-quantized\INT8' folder that we prepped above.
-    :: Let's run a simple example, keeping most parameters at default -- which will run all models on CPU.
-    txt_to_img.exe --model_dir="C:\Path\To\sd-1.5-square-quantized\INT8" --prompt="photo of an astronaut riding a horse on mars"
+    :: For --model_dir parameter, we will use the 'sd-1.5-square-quantized\' folder that was created from
+    :: the git clone.
+    :: We add additional parameter of --unet_subdir=INT8 to specify that we want the unet mode in
+    :: C:\Path\To\sd-1.5-square-quantized\INT8 to be used.
+    txt_to_img.exe --model_dir="C:\Path\To\sd-1.5-square-quantized" --unet_subdir="INT8" --prompt="photo of an astronaut riding a horse on mars"
 
     :: After generating an image, it will be displayed within a window. To generate another image using the same configuration,
     ::  click on the window and press 'c'. Otherwise if you want to quit, press 'q'.
 
     :: Here is a more advanced example, which makes use of negative prompt, as well as taking advantage of all accelerators -- CPU, GPU, and NPU (available on Intel Core Ultra):
-    txt_to_img.exe --model_dir="C:\Path\To\sd-1.5-square-quantized\INT8"  --prompt="professional photo of astronaut riding a horse on the moon" --negative_prompt="lowres, bad quality, monochrome" --text_encoder_device=CPU --unet_positive_device=NPU --unet_negative_device=GPU --vae_decoder_device=GPU
+    txt_to_img.exe --model_dir="C:\Path\To\sd-1.5-square-quantized\"  --unet_subdir="INT8" --prompt="professional photo of astronaut riding a horse on the moon" --negative_prompt="lowres, bad quality, monochrome" --text_encoder_device=CPU --unet_positive_device=NPU --unet_negative_device=GPU --vae_decoder_device=GPU
 
-    
+    :: Here is an example that uses FP16 version of unet. Note that this model is batch2, so we can't split 
+    :: UNet across 2 different devices. So, we set both unet_positive_device / unet_negative_device parameters to GPU.
+    txt_to_img.exe --model_dir="C:\Path\To\sd-1.5-square-quantized\"  --unet_subdir="FP16" --prompt="professional photo of astronaut riding a horse on the moon" --negative_prompt="lowres, bad quality, monochrome" --text_encoder_device=CPU --unet_positive_device=GPU --unet_negative_device=GPU --vae_decoder_device=GPU
     
     

--- a/samples/txt_to_audio.cpp
+++ b/samples/txt_to_audio.cpp
@@ -21,6 +21,7 @@ void print_usage()
     std::cout << "--guidance_scale=8.0 " << std::endl;
     std::cout << "--num_inference_steps=20 " << std::endl;
     std::cout << "--model_dir=\"C:\\Path\\To\\Some\\Model_Dir\" " << std::endl;
+    std::cout << "--unet_subdir=\"INT8\" or \"FP16\"" << std::endl;
     std::cout << "--text_encoder_device=CPU" << std::endl;
     std::cout << "--unet_positive_device=CPU" << std::endl;
     std::cout << "--unet_negative_device=CPU" << std::endl;
@@ -47,6 +48,7 @@ int main(int argc, char* argv[])
         std::optional<std::string> negative_prompt;
         std::optional<std::string> seed_str;
         std::optional<std::string> model_dir;
+        std::optional<std::string> unet_subdir;
         std::optional<std::string> guidance_scale_str;
         std::optional<std::string> num_inference_steps_str;
 
@@ -66,6 +68,7 @@ int main(int argc, char* argv[])
         guidance_scale_str = cmdline_parser.get_value_for_key("guidance_scale");
         num_inference_steps_str = cmdline_parser.get_value_for_key("num_inference_steps");
         model_dir = cmdline_parser.get_value_for_key("model_dir");
+        unet_subdir = cmdline_parser.get_value_for_key("unet_subdir");
         text_encoder_device = cmdline_parser.get_value_for_key("text_encoder_device");
         unet_positive_device = cmdline_parser.get_value_for_key("unet_positive_device");
         unet_negative_device = cmdline_parser.get_value_for_key("unet_negative_device");
@@ -140,11 +143,11 @@ int main(int argc, char* argv[])
 
         std::cout << "guidance_scale = " << guidance_scale << std::endl;
         std::cout << "scheduler = " << *scheduler << std::endl;
-    
+
         using namespace std::chrono;
         using Clock = std::chrono::high_resolution_clock;
         uint64_t  t0 = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-        cpp_stable_diffusion_ov::StableDiffusionPipeline sd_pipeline(*model_dir, {},
+        cpp_stable_diffusion_ov::StableDiffusionPipeline sd_pipeline(*model_dir, unet_subdir, {},
             *text_encoder_device, *unet_positive_device, *unet_negative_device, *vae_decoder_device);
         uint64_t  t1 = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
         std::cout << "Created StableDiffusionPipeline object in " << (double)(t1 - t0) / 1000.0 << " seconds." << std::endl;

--- a/samples/txt_to_audio_interpolate.cpp
+++ b/samples/txt_to_audio_interpolate.cpp
@@ -64,6 +64,7 @@ void print_usage()
     std::cout << "--guidance_scale_end=7.0 " << std::endl;
     std::cout << "--num_inference_steps=20 " << std::endl;
     std::cout << "--model_dir=\"C:\\Path\\To\\Some\\Model_Dir\" " << std::endl;
+    std::cout << "--unet_subdir=\"INT8\" or \"FP16\"" << std::endl;
     std::cout << "--text_encoder_device=CPU" << std::endl;
     std::cout << "--unet_positive_device=CPU" << std::endl;
     std::cout << "--unet_negative_device=CPU" << std::endl;
@@ -94,6 +95,7 @@ int main(int argc, char* argv[])
         std::optional<std::string> seed_start_str;
         std::optional<std::string> seed_end_str;
         std::optional<std::string> model_dir;
+        std::optional<std::string> unet_subdir;
         std::optional<std::string> guidance_scale_start_str;
         std::optional<std::string> guidance_scale_end_str;
         std::optional<std::string> num_inference_steps_str;
@@ -122,6 +124,7 @@ int main(int argc, char* argv[])
         guidance_scale_end_str = cmdline_parser.get_value_for_key("guidance_scale_end");
         num_inference_steps_str = cmdline_parser.get_value_for_key("num_inference_steps");
         model_dir = cmdline_parser.get_value_for_key("model_dir");
+        unet_subdir = cmdline_parser.get_value_for_key("unet_subdir");
         text_encoder_device = cmdline_parser.get_value_for_key("text_encoder_device");
         unet_positive_device = cmdline_parser.get_value_for_key("unet_positive_device");
         unet_negative_device = cmdline_parser.get_value_for_key("unet_negative_device");
@@ -235,7 +238,8 @@ int main(int argc, char* argv[])
             cancelAfter.cancel_after_n_unet_its = std::stoi(*cancel_after);
         }
   
-        cpp_stable_diffusion_ov::StableDiffusionAudioInterpolationPipeline riffusion_pipeline(*model_dir, {},
+        cpp_stable_diffusion_ov::StableDiffusionAudioInterpolationPipeline riffusion_pipeline(*model_dir, unet_subdir, 
+            {},
             *text_encoder_device,
             *unet_positive_device,
             *unet_negative_device,

--- a/samples/txt_to_img.cpp
+++ b/samples/txt_to_img.cpp
@@ -18,6 +18,7 @@ void print_usage()
     std::cout << "--guidance_scale=8.0 " << std::endl;
     std::cout << "--num_inference_steps=20 " << std::endl;
     std::cout << "--model_dir=\"C:\\Path\\To\\Some\\Model_Dir\" " << std::endl;
+    std::cout << "--unet_subdir=\"INT8\" or \"FP16\"" << std::endl;
     std::cout << "--text_encoder_device=CPU" << std::endl;
     std::cout << "--unet_positive_device=CPU" << std::endl;
     std::cout << "--unet_negative_device=CPU" << std::endl;
@@ -68,6 +69,7 @@ int main(int argc, char* argv[])
         std::optional<std::string> negative_prompt;
         std::optional<std::string> seed_str;
         std::optional<std::string> model_dir;
+        std::optional<std::string> unet_subdir;
         std::optional<std::string> guidance_scale_str;
         std::optional<std::string> num_inference_steps_str;
 
@@ -89,6 +91,8 @@ int main(int argc, char* argv[])
         guidance_scale_str = cmdline_parser.get_value_for_key("guidance_scale");
         num_inference_steps_str = cmdline_parser.get_value_for_key("num_inference_steps");
         model_dir = cmdline_parser.get_value_for_key("model_dir");
+        unet_subdir = cmdline_parser.get_value_for_key("unet_subdir");
+
         text_encoder_device = cmdline_parser.get_value_for_key("text_encoder_device");
         unet_positive_device = cmdline_parser.get_value_for_key("unet_positive_device");
         unet_negative_device = cmdline_parser.get_value_for_key("unet_negative_device");
@@ -174,7 +178,7 @@ int main(int argc, char* argv[])
         using namespace std::chrono;
         using Clock = std::chrono::high_resolution_clock;
         uint64_t  t0 = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-        cpp_stable_diffusion_ov::StableDiffusionPipeline sd_pipeline(*model_dir, {},
+        cpp_stable_diffusion_ov::StableDiffusionPipeline sd_pipeline(*model_dir, unet_subdir, {},
             *text_encoder_device, *unet_positive_device, *unet_negative_device, *vae_decoder_device);
         uint64_t  t1 = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
         std::cout << "Created StableDiffusionPipeline object in " << (double)(t1 - t0) / 1000.0 << " seconds." << std::endl;

--- a/samples/txt_to_img_interpolate.cpp
+++ b/samples/txt_to_img_interpolate.cpp
@@ -20,6 +20,7 @@ void print_usage()
     std::cout << "--guidance_scale=8.0 " << std::endl;
     std::cout << "--num_inference_steps=20 " << std::endl;
     std::cout << "--model_dir=\"C:\\Path\\To\\Some\\Model_Dir\" " << std::endl;
+    std::cout << "--unet_subdir=\"INT8\" or \"FP16\"" << std::endl;
     std::cout << "--text_encoder_device=CPU" << std::endl;
     std::cout << "--unet_positive_device=CPU" << std::endl;
     std::cout << "--unet_negative_device=CPU" << std::endl;
@@ -50,6 +51,7 @@ int main(int argc, char* argv[])
         std::optional<std::string> seed_start_str;
         std::optional<std::string> seed_end_str;
         std::optional<std::string> model_dir;
+        std::optional<std::string> unet_subdir;
         std::optional<std::string> guidance_scale_str;
         std::optional<std::string> num_inference_steps_str;
 
@@ -73,6 +75,7 @@ int main(int argc, char* argv[])
         guidance_scale_str = cmdline_parser.get_value_for_key("guidance_scale");
         num_inference_steps_str = cmdline_parser.get_value_for_key("num_inference_steps");
         model_dir = cmdline_parser.get_value_for_key("model_dir");
+        unet_subdir = cmdline_parser.get_value_for_key("unet_subdir");
         text_encoder_device = cmdline_parser.get_value_for_key("text_encoder_device");
         unet_positive_device = cmdline_parser.get_value_for_key("unet_positive_device");
         unet_negative_device = cmdline_parser.get_value_for_key("unet_negative_device");
@@ -188,7 +191,7 @@ int main(int argc, char* argv[])
         using namespace std::chrono;
         using Clock = std::chrono::high_resolution_clock;
         uint64_t  t0 = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-        cpp_stable_diffusion_ov::StableDiffusionInterpolationPipeline sd_pipeline(*model_dir, {},
+        cpp_stable_diffusion_ov::StableDiffusionInterpolationPipeline sd_pipeline(*model_dir, unet_subdir, {},
             *text_encoder_device, *unet_positive_device, *unet_negative_device, *vae_decoder_device);
         uint64_t  t1 = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
         std::cout << "Created StableDiffusionInterpolationPipeline object in " << (double)(t1 - t0) / 1000.0 << " seconds." << std::endl;

--- a/stable_diffusion_ov/CMakeLists.txt
+++ b/stable_diffusion_ov/CMakeLists.txt
@@ -26,6 +26,7 @@ set( STABLE_DIFFUSION_OV_PRIVATE_HEADERS
 	pipelines/unet_loop.h
 	pipelines/unet_loop_split.h
 	pipelines/unet_loop_sd15_internal_blobs.h
+	pipelines/unet_loop_batch2.h
 	schedulers/scheduler.h
 	schedulers/pndm_scheduler.h
 	schedulers/ustm_scheduler.h
@@ -52,6 +53,7 @@ set( STABLE_DIFFUSION_OV_SOURCES
 	pipelines/stable_diffusion_interpolation_pipeline.cpp
 	pipelines/unet_loop_split.cpp
 	pipelines/unet_loop_sd15_internal_blobs.cpp
+	pipelines/unet_loop_batch2.cpp
 	schedulers/pndm_scheduler.cpp
 	schedulers/ustm_scheduler.cpp
 	schedulers/euler_discrete_scheduler.cpp

--- a/stable_diffusion_ov/include/cpp_stable_diffusion_audio_ov/stable_diffusion_audio_interpolation_pipeline.h
+++ b/stable_diffusion_ov/include/cpp_stable_diffusion_audio_ov/stable_diffusion_audio_interpolation_pipeline.h
@@ -11,6 +11,7 @@ namespace cpp_stable_diffusion_ov
     public:
 
         StableDiffusionAudioInterpolationPipeline(std::string model_folder,
+            std::optional< std::string > unet_subdir,
             std::optional< std::string > cache = {},
             std::string text_encoder_device = "CPU",
             std::string unet_positive_device = "CPU",

--- a/stable_diffusion_ov/include/cpp_stable_diffusion_ov/model_collateral_cache.h
+++ b/stable_diffusion_ov/include/cpp_stable_diffusion_ov/model_collateral_cache.h
@@ -36,6 +36,7 @@ namespace cpp_stable_diffusion_ov
         }
 
         ModelCollateral GetModelCollateral(std::string model_folder,
+            std::optional<std::string> unet_sub_dir,
             std::optional<std::string> cache_dir,
             std::string text_encoder_device,
             std::string unet_positive_device,

--- a/stable_diffusion_ov/include/cpp_stable_diffusion_ov/stable_diffusion_interpolation_pipeline.h
+++ b/stable_diffusion_ov/include/cpp_stable_diffusion_ov/stable_diffusion_interpolation_pipeline.h
@@ -11,6 +11,7 @@ namespace cpp_stable_diffusion_ov
     public:
 
         StableDiffusionInterpolationPipeline(std::string model_folder,
+            std::optional< std::string > unet_subdir,
             std::optional< std::string > cache = {},
             std::string text_encoder_device = "CPU",
             std::string unet_positive_device = "CPU",

--- a/stable_diffusion_ov/include/cpp_stable_diffusion_ov/stable_diffusion_pipeline.h
+++ b/stable_diffusion_ov/include/cpp_stable_diffusion_ov/stable_diffusion_pipeline.h
@@ -25,6 +25,7 @@ namespace cpp_stable_diffusion_ov
     public:
 
         StableDiffusionPipeline(std::string model_folder,
+            std::optional< std::string > unet_subdir,
             std::optional< std::string > cache = {},
             std::string text_encoder_device = "CPU",
             std::string unet_positive_device = "CPU",

--- a/stable_diffusion_ov/pipelines/riffusion_audio_to_audio_pipeline.cpp
+++ b/stable_diffusion_ov/pipelines/riffusion_audio_to_audio_pipeline.cpp
@@ -26,7 +26,8 @@ namespace cpp_stable_diffusion_ov
         std::string vae_decoder_device,
         std::string vae_encoder_device)
     {
-        _stable_diffusion_pipeline = std::make_shared< StableDiffusionPipeline >(model_folder, cache_folder, text_encoder_device,
+        std::optional<std::string> subdir;
+        _stable_diffusion_pipeline = std::make_shared< StableDiffusionPipeline >(model_folder, subdir, cache_folder, text_encoder_device,
             unet_positive_device, unet_negative_device, vae_decoder_device, vae_encoder_device);
 
         _spec_img_converterL = std::make_shared < SpectrogramImageConverter >();

--- a/stable_diffusion_ov/pipelines/stable_diffusion_audio_interpolation_pipeline.cpp
+++ b/stable_diffusion_ov/pipelines/stable_diffusion_audio_interpolation_pipeline.cpp
@@ -23,13 +23,14 @@ namespace cpp_stable_diffusion_ov
 {
 
     StableDiffusionAudioInterpolationPipeline::StableDiffusionAudioInterpolationPipeline(std::string model_folder,
+        std::optional< std::string > unet_subdir,
         std::optional< std::string > cache,
         std::string text_encoder_device,
         std::string unet_positive_device,
         std::string unet_negative_device,
         std::string vae_decoder_device,
         std::string vae_encoder_device)
-        : StableDiffusionInterpolationPipeline(model_folder, cache, text_encoder_device, unet_positive_device,
+        : StableDiffusionInterpolationPipeline(model_folder, unet_subdir, cache, text_encoder_device, unet_positive_device,
             unet_negative_device, vae_decoder_device, vae_encoder_device)
     {
 

--- a/stable_diffusion_ov/pipelines/stable_diffusion_interpolation_pipeline.cpp
+++ b/stable_diffusion_ov/pipelines/stable_diffusion_interpolation_pipeline.cpp
@@ -14,13 +14,14 @@
 namespace cpp_stable_diffusion_ov
 {
     StableDiffusionInterpolationPipeline::StableDiffusionInterpolationPipeline(std::string model_folder,
+        std::optional< std::string > unet_subdir,
         std::optional< std::string > cache,
         std::string text_encoder_device,
         std::string unet_positive_device,
         std::string unet_negative_device,
         std::string vae_decoder_device,
         std::string vae_encoder_device)
-        : StableDiffusionPipeline(model_folder, cache, text_encoder_device, unet_positive_device,
+        : StableDiffusionPipeline(model_folder, unet_subdir, cache, text_encoder_device, unet_positive_device,
             unet_negative_device, vae_decoder_device, vae_encoder_device)
     {
 

--- a/stable_diffusion_ov/pipelines/stable_diffusion_pipeline.cpp
+++ b/stable_diffusion_ov/pipelines/stable_diffusion_pipeline.cpp
@@ -25,6 +25,7 @@
 namespace cpp_stable_diffusion_ov
 {
     StableDiffusionPipeline::StableDiffusionPipeline(std::string model_folder,
+        std::optional< std::string > unet_subdir,
         std::optional< std::string > cache,
         std::string text_encoder_device,
         std::string unet_positive_device,
@@ -50,7 +51,7 @@ namespace cpp_stable_diffusion_ov
             cache_dir = *cache;
         }
 
-        auto m = ModelCollateralCache::instance()->GetModelCollateral(model_folder, cache_dir, text_encoder_device, unet_positive_device,
+        auto m = ModelCollateralCache::instance()->GetModelCollateral(model_folder, unet_subdir, cache_dir, text_encoder_device, unet_positive_device,
             unet_negative_device, vae_decoder_device, vae_encoder_device);
 
         _unet_loop = m.unet_loop;

--- a/stable_diffusion_ov/pipelines/unet_loop_batch2.cpp
+++ b/stable_diffusion_ov/pipelines/unet_loop_batch2.cpp
@@ -1,0 +1,153 @@
+// Copyright(C) 2024 Intel Corporation
+// SPDX - License - Identifier: Apache - 2.0
+#include "pipelines/unet_loop_batch2.h"
+#include "cpp_stable_diffusion_ov/openvino_model_utils.h"
+#include <chrono>
+
+//todo: this should change to header for base scheduler class once it exists.
+#include "schedulers/scheduler.h"
+
+namespace cpp_stable_diffusion_ov
+{
+    UNetLoopBatch2::UNetLoopBatch2(std::shared_ptr<ov::Model>  unet_model,
+        std::string device,
+        size_t max_tok_len,
+        size_t img_width,
+        size_t img_height,
+        ov::Core& core)
+        : _device(device)
+    {
+        logBasicModelInfo(unet_model);
+
+        //we'll run batch size 2, but these are the shapes that we expect the 'sample'latent' and encoder 
+        // hidden states tensors to be passed into operator() below. 
+        _sample_shape = ov::Shape{ 1, 4, img_height / 8, img_width / 8 };
+        _encoder_hidden_states_shape = ov::Shape{ 1, max_tok_len, 768 };
+
+        std::cout << "UNet model info:" << std::endl;
+        logBasicModelInfo(unet_model);
+
+        {
+            std::cout << "Compiling batch2 unet model for " << device << "..." << std::endl;
+            auto compiled_model = core.compile_model(unet_model, device);
+            std::cout << "Compiling batch2 unet model for " << device << " done" << std::endl;
+            _infer_request = compiled_model.create_infer_request();
+        }
+    }
+
+    ov::Tensor UNetLoopBatch2::operator()(const std::vector<double>& timesteps, ov::Tensor latents, ov::Tensor encoder_hidden_states_positive,
+        ov::Tensor encoder_hidden_states_negative, float guidance_scale, std::shared_ptr<Scheduler> scheduler,
+        std::optional<std::pair< CallbackFuncUnetIteration, void*>> unet_iteration_callback)
+    {
+        if (latents.get_shape() != _sample_shape)
+        {
+            throw std::invalid_argument("invalid sample shape");
+        }
+
+        if (encoder_hidden_states_positive.get_shape() != _encoder_hidden_states_shape)
+        {
+            throw std::invalid_argument("invalid encoder_hidden_states shape");
+        }
+
+        if (encoder_hidden_states_negative.get_shape() != _encoder_hidden_states_shape)
+        {
+            throw std::invalid_argument("invalid encoder_hidden_states shape");
+        }
+
+        //copy the encoder hidden states to the unet batch2 encoder_hidden_states tensor.
+        // This can be done once up-front, as this tensor doesn't change per unet iteration.
+        {
+            auto encoder_hidden_states_batch2 = _infer_request.get_tensor("encoder_hidden_states");
+
+            auto* pEncoderHiddenStatesBatch2 = encoder_hidden_states_batch2.data<float>();
+            auto* pEncoderHiddenStatesPos = encoder_hidden_states_positive.data<float>();
+            auto* pEncoderHiddenStatesNeg = encoder_hidden_states_negative.data<float>();
+
+            std::memcpy(pEncoderHiddenStatesBatch2, pEncoderHiddenStatesPos, (encoder_hidden_states_batch2.get_size()/2) * sizeof(float));
+            std::memcpy(pEncoderHiddenStatesBatch2 + (encoder_hidden_states_batch2.get_size() / 2), pEncoderHiddenStatesNeg, (encoder_hidden_states_batch2.get_size()/2) * sizeof(float));
+        }
+
+        using namespace std::chrono;
+        using Clock = std::chrono::high_resolution_clock;
+        uint64_t  unet_start = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+        for (size_t i = 0; i < timesteps.size(); i++)
+        {
+            uint64_t  ts = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+            auto t = timesteps[i];
+            std::cout << "i =  " << i << ", t = " << t << std::endl;
+
+            auto latent_model_input = ov::Tensor(latents.get_element_type(), latents.get_shape());
+            
+            //the scheduler scale input modifies latent_model_input in-place. We need to maintain pre-scaled
+            // version for some calculations later on, this is why we make a copy of 'latents' here.
+            latents.copy_to(latent_model_input);
+
+            scheduler->scale_model_input(latent_model_input, t);
+
+            uint64_t  tus = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+
+            //expand to batch size 2
+            {
+                auto latent_model_input_batch2 = _infer_request.get_tensor("latent_model_input");
+
+                auto* pLatentModelInputBatch2 = latent_model_input_batch2.data<float>();
+                auto* pLatentModelInputBatch1 = latent_model_input.data<float>();
+                std::memcpy(pLatentModelInputBatch2, pLatentModelInputBatch1, latent_model_input.get_size() * sizeof(float));
+                std::memcpy(pLatentModelInputBatch2 + latent_model_input.get_size(), pLatentModelInputBatch1, latent_model_input.get_size() * sizeof(float));
+            }
+
+            //set the timestamp
+            auto timestep_tensor = _infer_request.get_tensor("t");
+            auto* pTimestep = timestep_tensor.data<double>();
+            *pTimestep = t;
+
+            // run unet
+            _infer_request.infer();
+
+            uint64_t  tue = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+            std::cout << "unet portion =  " << (double)(tue - tus) / 1000.0 << " seconds." << std::endl;
+
+            auto noise_pred = _infer_request.get_output_tensor();
+
+            //noise_pred is shape 2,4,64,64, so split this batch2 tensor to produce noise_pred_text & noise_pred_uncond.
+            // We just wrap existing tensor buffer here.
+            ov::Tensor noise_pred_text, noise_pred_uncond;
+            {
+                float* pNoisePred = noise_pred.data<float>();
+                auto noise_pred_shape = noise_pred.get_shape();
+                noise_pred_shape[0] = 1;
+
+                noise_pred_text = ov::Tensor(noise_pred.get_element_type(), noise_pred_shape, pNoisePred);
+                noise_pred_uncond = ov::Tensor(noise_pred.get_element_type(), noise_pred_shape, pNoisePred + noise_pred.get_size()/2);
+            }
+
+            //noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+            auto* pNoisePredUncond = noise_pred_uncond.data<float>();
+            auto* pNoisePredText = noise_pred_text.data<float>();
+            for (size_t i = 0; i < noise_pred_text.get_size(); i++)
+            {
+                pNoisePredText[i] = pNoisePredUncond[i] + guidance_scale * (pNoisePredText[i] - pNoisePredUncond[i]);
+            }
+            
+            //run scheduler
+            latents = scheduler->step(noise_pred_text, t, latents);
+            uint64_t  te = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+            std::cout << "UNet iteration " << i << " took " << (double)(te - ts) / 1000.0 << " seconds. " <<
+                "it/s = " << (double)(i + 1) / ((double)(te - unet_start) / 1000.0) << std::endl;
+
+            if (unet_iteration_callback)
+            {
+                if (!unet_iteration_callback->first(i, timesteps.size(), unet_iteration_callback->second))
+                {
+                    std::cout << "Cancelled!" << std::endl;
+                    return {};
+                }
+            }
+        }
+        uint64_t  unet_end = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+        std::cout << "Overall UNet Loop (" << timesteps.size() << ") iterations took " << (double)(unet_end - unet_start) / 1000.0 << " seconds." << std::endl;
+        std::cout << "it/s = " << (double)timesteps.size() / ((double)(unet_end - unet_start) / 1000.0) << std::endl;
+
+        return latents;
+    }
+}

--- a/stable_diffusion_ov/pipelines/unet_loop_batch2.h
+++ b/stable_diffusion_ov/pipelines/unet_loop_batch2.h
@@ -1,4 +1,4 @@
-// Copyright(C) 2023 Intel Corporation
+// Copyright(C) 2024 Intel Corporation
 // SPDX - License - Identifier: Apache - 2.0
 #pragma once
 
@@ -10,15 +10,13 @@ namespace cpp_stable_diffusion_ov
 {
     class Scheduler;
 
-    //'Standard' Stable Diffusion UNet loop that splits inference for positive and negative prompts 
-    // (which adds the ability to run them across 2 separate devices)
-    class UNetLoopSplit : public UNetLoop
+    //'Standard' Stable Diffusion UNet loop that performs single inference for +/- prompts (batch2)
+    class UNetLoopBatch2 : public UNetLoop
     {
     public:
 
-        UNetLoopSplit(std::shared_ptr<ov::Model> unet_model,
-            std::string device_unet_positive_prompt,
-            std::string device_unet_negative_prompt,
+        UNetLoopBatch2(std::shared_ptr<ov::Model> unet_model,
+            std::string device,
             size_t max_tok_len, size_t img_width,
             size_t img_height,
             ov::Core &core);
@@ -37,11 +35,7 @@ namespace cpp_stable_diffusion_ov
 
         ov::Shape _sample_shape;
         ov::Shape _encoder_hidden_states_shape;
-        ov::InferRequest _infer_request[2];
-        std::string _device_unet_positive_prompt;
-        std::string _device_unet_negative_prompt;
-
-        void _run_unet_async(ov::Tensor latents, double timestep, ov::Tensor encoder_hidden_states, size_t infer_request_index);
-
+        ov::InferRequest _infer_request;
+        std::string _device;
     };
 }

--- a/stable_diffusion_ov/pipelines/unet_loop_split.cpp
+++ b/stable_diffusion_ov/pipelines/unet_loop_split.cpp
@@ -9,7 +9,7 @@
 
 namespace cpp_stable_diffusion_ov
 {
-    UNetLoopSplit::UNetLoopSplit(std::string model_path,
+    UNetLoopSplit::UNetLoopSplit(std::shared_ptr<ov::Model> model,
         std::string device_unet_positive_prompt,
         std::string device_unet_negative_prompt,
         size_t max_tok_len,
@@ -18,21 +18,8 @@ namespace cpp_stable_diffusion_ov
         ov::Core& core)
         : _device_unet_positive_prompt(device_unet_positive_prompt), _device_unet_negative_prompt(device_unet_negative_prompt)
     {
-        //Read the OpenVINO encoder IR (.xml/.bin) from disk, producing an ov::Model object.
-        auto model = core.read_model(model_path);
-
-        logBasicModelInfo(model);
-
         _sample_shape = ov::Shape{ 1, 4, img_height / 8, img_width / 8 };
         _encoder_hidden_states_shape = ov::Shape{ 1, max_tok_len, 768 };
-        std::map<size_t, ov::PartialShape> reshape_map;
-        reshape_map[0] = _sample_shape;
-        reshape_map[2] = _encoder_hidden_states_shape;
-        model->reshape(reshape_map);
-
-        //ov::preprocess::PrePostProcessor ppp(model);
-        //ppp.input("timestep").tensor().set_element_type(ov::element::f64);
-        //model = ppp.build();
 
         std::cout << "UNet model info:" << std::endl;
         logBasicModelInfo(model);


### PR DESCRIPTION
    1. Our HF repos are usually arranged as a 'base' folder (containing vae, text encoder models, etc.), and
     subfolders that store the unet model collateral. For example, 'FP16' and 'INT8'. This change-set adds the
     ability to set both the 'base' directory, and optionally the 'subdir' to find the unet model. If the subdir
     isn't set, then it will fall back to the old behavior and look for the unet model (and other related collateral)
     in the 'base' model folder.

    2. Add a new 'batch2' specific unet loop class to support batch2 unet models.
    3. Update all of the cmdline samples, and Windows documentation to reflect the new subdir feature.